### PR TITLE
docs: updateREADME.md to clarify plugin loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,13 @@ import { defineConfig } from 'cypress';
 import { initPlugin } from '@frsource/cypress-plugin-visual-regression-diff/plugins';
 
 export default defineConfig({
-  // setupNodeEvents can be defined in either
-  // the e2e or component configuration
+  // initPlugin must be called in the section where it is used: e2e or component
   e2e: {
+    setupNodeEvents(on, config) {
+      initPlugin(on, config);
+    }
+  },
+  component: {
     setupNodeEvents(on, config) {
       initPlugin(on, config);
     }


### PR DESCRIPTION
Clarify plugin loading process when running as a `component` instead of `e2e`.

The `example` project does a good job of showing the `initPlugin` call in both `e2e` and `component` objects.  Unfortunately, I did not notice that until I was 30 minutes past spotting the obvious.  Clarifying the README might help another lost dev.