### PR TITLE
feat: add matchAgainstPath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ cy.matchImage({
   // title used for naming the image file
   // default: Cypress.currentTest.titlePath (your test title)
   title: `${Cypress.currentTest.titlePath.join(' ')} (${Cypress.browser.displayName})`
+  // pass a path to custom image that should be used for comparison
+  // instead of checking against the image from previous run
+  // default: undefined
+  matchAgainstPath: '/path/to/reference-image.png'
 })
 ```
 

--- a/example/cypress/e2e/spec.cy.js
+++ b/example/cypress/e2e/spec.cy.js
@@ -3,5 +3,9 @@ describe('My First Test', () => {
     cy.visit('/')
     cy.contains('h1', 'Welcome to Your Vue.js App')
     cy.matchImage()
+      .then(({ imgNewPath }) => {
+        // match against image from custom path
+        cy.matchImage({ matchAgainstPath: imgNewPath });
+      })
   })
 })


### PR DESCRIPTION
allow to compare screenshots against custom reference images
add docs
add example test case

BREAKING CHANGE: matchImage returns object containing comparison details from now on (previously was rereturning subject from a chain)

references #88 