### PR TITLE
feat: introduce imagesPath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,13 @@ cy.matchImage({
   // default: false
   updateImages: true,
   // directory path in which screenshot images will be stored
-  // image visualiser will normalise path separators depending on OS it's being run within, so always use / for nested paths
-  // default: '__image_snapshots__'
-  imagesDir: 'this-might-be-your-custom/maybe-nested-directory',
+  // relative path are resolved against project root
+  // absolute paths (both on unix and windows OS) supported
+  // path separators will be normalised by the plugin depending on OS, you should always use / as path separator, e.g.: C:/my-directory/nested for windows-like drive notation
+  // There are one special variable available to be used in the path:
+  // - {spec_path} - relative path leading from project root to the current spec file directory (e.g. `/src/components/my-tested-component`)
+  // default: '{spec_path}/__image_snapshots__'
+  imagesPath: 'this-might-be-your-custom/maybe-nested-directory',
   // maximum threshold above which the test should fail
   // default: 0.01
   maxDiffThreshold: 0.1,

--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "test:open": "vue-cli-service test:e2e --env \"pluginVisualRegressionImagesPath={spec_path}/__image_snapshots_locals__\"",
+    "test:open": "vue-cli-service test:e2e --env \"pluginVisualRegressionImagesPath={spec_path}/__image_snapshots_local__\"",
     "test:run": "vue-cli-service test:e2e",
     "test:ct": "yarn test:open --component",
     "test:ct:ci": "yarn test:run --component --headless",

--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "test:open": "vue-cli-service test:e2e --env \"pluginVisualRegressionImagesDir=__image_snapshots_local__\"",
+    "test:open": "vue-cli-service test:e2e --env \"pluginVisualRegressionImagesPath={spec_path}/__image_snapshots_locals__\"",
     "test:run": "vue-cli-service test:e2e",
     "test:ct": "yarn test:open --component",
     "test:ct:ci": "yarn test:run --component --headless",

--- a/src/afterScreenshot.hook.test.ts
+++ b/src/afterScreenshot.hook.test.ts
@@ -1,9 +1,9 @@
 import { it, expect, describe } from "vitest";
 import path from "path";
 import { promises as fs, existsSync } from "fs";
-import { initAfterScreenshotHook } from "./afterScreenshot.hook";
+import { initAfterScreenshotHook, parseAbsolutePath } from "./afterScreenshot.hook";
 import { dir, file, setGracefulCleanup } from "tmp-promise";
-import { IMAGE_SNAPSHOT_PREFIX } from "./constants";
+import { IMAGE_SNAPSHOT_PREFIX, PATH_VARIABLES } from "./constants";
 
 setGracefulCleanup();
 
@@ -29,5 +29,25 @@ describe("initAfterScreenshotHook", () => {
     expect(existsSync(expectedNewPath)).toBe(true);
 
     await fs.unlink(expectedNewPath);
+  });
+});
+
+describe('parseAbsolutePath', () => {
+  const projectRoot = '/its/project/root';
+
+  it('resolves relative paths against project root', () => {
+    expect(parseAbsolutePath({ screenshotPath: 'some/path.png', projectRoot }))
+      .toBe('/its/project/root/some/path.png');
+  });
+
+  it('builds proper win paths when found', () => {
+    expect(parseAbsolutePath({ screenshotPath: `${PATH_VARIABLES.winSystemRootPath}/D/some/path.png`, projectRoot }))
+    // that's expected output accorind to https://stackoverflow.com/a/64135721/8805801
+    .toBe('D:\\/some/path.png');
+  });
+
+  it('resolves relative paths against project root', () => {
+    expect(parseAbsolutePath({ screenshotPath: `${PATH_VARIABLES.unixSystemRootPath}/some/path.png`, projectRoot }))
+      .toBe('/some/path.png');
   });
 });

--- a/src/afterScreenshot.hook.ts
+++ b/src/afterScreenshot.hook.ts
@@ -25,7 +25,7 @@ const getConfigVariableOrThrow = <K extends keyof Cypress.PluginConfigOptions>(
 };
 /* c8 ignore stop */
 
-const parseAbsolutePath = ({
+export const parseAbsolutePath = ({
   screenshotPath,
   projectRoot,
 }: {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,9 +9,10 @@ export enum FILE_SUFFIX {
 }
 
 export const TASK = {
-  getScreenshotPath: `${PLUGIN_NAME}-getScreenshotPath`,
+  getScreenshotPathInfo: `${PLUGIN_NAME}-getScreenshotPathInfo`,
   compareImages: `${PLUGIN_NAME}-compareImages`,
   approveImage: `${PLUGIN_NAME}-approveImage`,
+  cleanupImages: `${PLUGIN_NAME}-cleanupImages`,
   doesFileExist: `${PLUGIN_NAME}-doesFileExist`,
   /* c8 ignore next */
 };
@@ -20,6 +21,8 @@ export const PATH_VARIABLES = {
   specPath: "{spec_path}",
   unixSystemRootPath: "{unix_system_root_path}",
   winSystemRootPath: "{win_system_root_path}",
-};
+} as const;
 
 export const WINDOWS_LIKE_DRIVE_REGEX = /^[A-Z]:$/;
+
+export const METADATA_KEY = "FRSOURCE_CPVRD_V";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,3 @@
-/* c8 ignore start */
 const PLUGIN_NAME = "cp-visual-regression-diff";
 export const LINK_PREFIX = `#${PLUGIN_NAME}-`;
 export const OVERLAY_CLASS = `${PLUGIN_NAME}-overlay`;
@@ -10,13 +9,17 @@ export enum FILE_SUFFIX {
 }
 
 export const TASK = {
-  getScreenshotPathInfo: `${PLUGIN_NAME}-getScreenshotPathInfo`,
+  getScreenshotPath: `${PLUGIN_NAME}-getScreenshotPath`,
   compareImages: `${PLUGIN_NAME}-compareImages`,
   approveImage: `${PLUGIN_NAME}-approveImage`,
-  cleanupImages: `${PLUGIN_NAME}-cleanupImages`,
   doesFileExist: `${PLUGIN_NAME}-doesFileExist`,
   /* c8 ignore next */
 };
 
-export const METADATA_KEY = "FRSOURCE_CPVRD_V";
-/* c8 ignore stop */
+export const PATH_VARIABLES = {
+  specPath: "{spec_path}",
+  unixSystemRootPath: "{unix_system_root_path}",
+  winSystemRootPath: "{win_system_root_path}",
+};
+
+export const WINDOWS_LIKE_DRIVE_REGEX = /^[A-Z]:$/;

--- a/src/screenshotPath.utils.ts
+++ b/src/screenshotPath.utils.ts
@@ -1,21 +1,34 @@
 import path from "path";
-import { FILE_SUFFIX, IMAGE_SNAPSHOT_PREFIX } from "./constants";
+import { FILE_SUFFIX, IMAGE_SNAPSHOT_PREFIX, PATH_VARIABLES, WINDOWS_LIKE_DRIVE_REGEX } from "./constants";
 import sanitize from "sanitize-filename";
 
 const nameCacheCounter: Record<string, number> = {};
 
 export const generateScreenshotPath = ({
   titleFromOptions,
-  imagesDir,
+  imagesPath,
   specPath,
 }: {
   titleFromOptions: string;
-  imagesDir: string;
+  imagesPath: string;
   specPath: string;
 }) => {
+    const parsePathPartVariables = (pathPart: string, i: number) => {
+      if (pathPart === PATH_VARIABLES.specPath) {
+        return path.dirname(specPath);
+      } else if (i === 0 && !pathPart) {
+        // when unix-like absolute path
+        return PATH_VARIABLES.unixSystemRootPath;
+      } else if (i === 0 && WINDOWS_LIKE_DRIVE_REGEX.test(pathPart)) {
+        // when win-like absolute path
+        return path.join(PATH_VARIABLES.winSystemRootPath, pathPart[0]);
+      }
+  
+      return pathPart;
+    };
+
   const screenshotPath = path.join(
-    path.dirname(specPath),
-    ...imagesDir.split("/"),
+    ...imagesPath.split("/").map(parsePathPartVariables),
     sanitize(titleFromOptions)
   );
 

--- a/src/task.hook.test.ts
+++ b/src/task.hook.test.ts
@@ -40,17 +40,59 @@ const writeTmpFixture = async (pathToWriteTo: string, fixtureName: string) => {
 };
 
 describe("getScreenshotPathInfoTask", () => {
+  const specPath = "some/nested/spec-path/spec.ts";
+
   it("returns sanitized path and title", () => {
     expect(
       getScreenshotPathInfoTask({
         titleFromOptions: "some-title-withśpęćiał人物",
-        imagesDir: "nested/images/dir",
-        specPath: "some/nested/spec-path/spec.ts",
+        imagesPath: "nested/images/dir",
+        specPath,
       })
     ).toEqual({
       screenshotPath:
-        "__cp-visual-regression-diff_snapshots__/some/nested/spec-path/nested/images/dir/some-title-withśpęćiał人物 #0.actual.png",
+        "__cp-visual-regression-diff_snapshots__/nested/images/dir/some-title-withśpęćiał人物 #0.actual.png",
       title: "some-title-withśpęćiał人物 #0.actual",
+    });
+  });
+
+  it("supports {spec_path} variable", () => {
+    expect(
+      getScreenshotPathInfoTask({
+        titleFromOptions: "some-title",
+        imagesPath: "{spec_path}/images/dir",
+        specPath,
+      })
+    ).toEqual({
+      screenshotPath:
+        "__cp-visual-regression-diff_snapshots__/some/nested/spec-path/images/dir/some-title #0.actual.png",
+      title: 'some-title #0.actual',
+    });
+  });
+
+  it("supports OS-specific absolute paths", () => {
+    expect(
+      getScreenshotPathInfoTask({
+        titleFromOptions: "some-title",
+        imagesPath: "/images/dir",
+        specPath,
+      })
+    ).toEqual({
+      screenshotPath:
+        "__cp-visual-regression-diff_snapshots__/{unix_system_root_path}/images/dir/some-title #0.actual.png",
+      title: 'some-title #0.actual',
+    });
+
+    expect(
+      getScreenshotPathInfoTask({
+        titleFromOptions: "some-title",
+        imagesPath: "C:/images/dir",
+        specPath,
+      })
+    ).toEqual({
+      screenshotPath:
+        "__cp-visual-regression-diff_snapshots__/{win_system_root_path}/C/images/dir/some-title #0.actual.png",
+      title: 'some-title #0.actual',
     });
   });
 });
@@ -60,7 +102,7 @@ describe("cleanupImagesTask", () => {
     const generateUsedScreenshotPath = async (projectRoot: string) => {
       const screenshotPathWithPrefix = generateScreenshotPath({
         titleFromOptions: "some-file",
-        imagesDir: "images",
+        imagesPath: "images",
         specPath: "some/spec/path",
       });
       return path.join(


### PR DESCRIPTION
allow relative path resolution
create special {spec_path} variable
allow absolute path resolution (under unix and win systems) refactor afterScreenshot hook to awaits
add deprecation message for imagesDir option
add docs info

BREAKING CHANGE: deprecate imagesDir option in favor of imagesPath - see docs for additional information

references issue #147

Signed-off-by: Jakub Freisler <jakub@frsource.org>