### PR TITLE
fix: return launchOptions so they are applied

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -8,6 +8,7 @@ const initForceDeviceScaleFactor = (on: Cypress.PluginEvents) => {
     if (browser.name === "chrome" || browser.name === "chromium") {
       launchOptions.args.push("--force-device-scale-factor=1");
       launchOptions.args.push("--high-dpi-support=1");
+      return launchOptions;
     } else if (browser.name === "electron" && browser.isHeaded) {
       // eslint-disable-next-line no-console
       console.log(


### PR DESCRIPTION
Hi, and thanks a bunch for this great tool 😄 

## Summary

According to the [Cypress documentation](https://docs.cypress.io/api/plugins/browser-launch-api#Modify-browser-launch-arguments) the `launchOptions` need to be returned for them to be used. Can confirm.

## Background

I ran into problems in https://github.com/fremtind/jokul/pull/3270 (Norwegian repo, sorry for the language barrier) where I'm looking to adopt this plugin as a replacement for `cypress-plugin-snapshots`.

We use Cypress to also run visual regression tests in [forced-colors mode](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors). We solve this with an environment variable and [this patch](https://github.com/fremtind/jokul/blob/8ed0f643e2bb02e2d553d3fb9f950151ca6fbc1c/patches/cypress-plugin-snapshots+1.4.4.patch)[^1] for `cypress-plugin-snapshots`. When I applied a similar patch to this plugin, the launch option was not applied.

Once I added the `return` statement to my patch the launch options worked as expected.

---

[^1]: We patch because Cypress doesn't support registering multiple `on(...)` functions to the same event, such as `on("before:browser:launch", ...)`. There's an open issue for this limitation in the Cypress repo.