### PR TITLE
fix: Add forceDeviceScaleFactor to MatchImageOptions

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -16,6 +16,7 @@ declare global {
       imagesDir?: string;
       imagesPath?: string;
       maxDiffThreshold?: number;
+      forceDeviceScaleFactor?: boolean;
       title?: string;
       matchAgainstPath?: string;
       // IDEA: to be implemented if support for files NOT from filesystem needed


### PR DESCRIPTION
👋  This PR adds a missing type allowed in the options object